### PR TITLE
fix cmake build error

### DIFF
--- a/Formula/cvc5.rb
+++ b/Formula/cvc5.rb
@@ -42,7 +42,7 @@ class Cvc5 < Formula
     system "bash", "-c", "export CMAKE_PREFIX_PATH=#{libexec}:$CMAKE_PREFIX_PATH; #{command}"
 
     chdir "build" do
-      system "make", "install"
+      system "bash", "-c", "export CMAKE_POLICY_VERSION_MINIMUM=3.5; make install"
     end
   end
 


### PR DESCRIPTION
I was getting a cmake error when I tried to install cvc5 from the tap.
Since this seems to originate from a third-party dependency, my quick-and-dirty fix was to provide `CMAKE_POLICY_VERSION_MINIMUM=3.5` as environment variable for `make install`.
After this change, the build succeeds. I hope this helps someone :)

<details><summary>Installation Error Log</summary>
2025-05-21 13:32:35 +0000

make
install

[  0%] Creating directories for 'CaDiCaL-EP'
[  0%] Creating directories for 'SymFPU-EP'
[  0%] Building CXX object src/context/CMakeFiles/cvc5context.dir/context.cpp.o
[  0%] Generating options/options.stamp
[  0%] Generating type_enumerator.cpp
[  0%] Generating rewrites.{h,cpp}
[  0%] Generating kind.h
[  0%] Creating directories for 'Poly-EP'
[  0%] Generating Trace_tags.h
[  0%] Performing download step (download, verify and extract) for 'CaDiCaL-EP'
[  0%] Performing download step (download, verify and extract) for 'SymFPU-EP'
[  0%] Performing download step (download, verify and extract) for 'Poly-EP'
-- Found Git: /opt/homebrew/Library/Homebrew/shims/mac/super/git (found version "2.39.5 (Apple Git-154)")
[  0%] Built target gen-options
[  0%] Building CXX object src/context/CMakeFiles/cvc5context.dir/context_mm.cpp.o
[  0%] Built target gen-tags
[  1%] Generating theory_traits.h
[  1%] Built target gen-versioninfo
[  1%] Generating smt2_tokens.h
[  1%] Built target gen-tokens
[  2%] Generating metakind.h
[  2%] Generating rewriter_tables.h
-- Poly-EP download command succeeded.  See also /private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/Poly-EP-stamp/Poly-EP-download-*.log
[  2%] No update step for 'Poly-EP'
[  2%] Built target cvc5context
[  2%] Performing patch step for 'Poly-EP'
[  3%] Building CXX object src/base/CMakeFiles/cvc5base.dir/check.cpp.o
-- Poly-EP patch command succeeded.  See also /private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/Poly-EP-stamp/Poly-EP-patch-*.log
-- CaDiCaL-EP download command succeeded.  See also /private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/CaDiCaL-EP-stamp/CaDiCaL-EP-download-*.log
[  4%] Performing configure step for 'Poly-EP'
[  4%] No update step for 'CaDiCaL-EP'
CMake Error at /private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/Poly-EP-stamp/Poly-EP-configure-Production.cmake:37 (message):
  Command failed: 1

   '/opt/homebrew/opt/cmake/bin/cmake' '-DCMAKE_BUILD_TYPE=Release' '-DCMAKE_INSTALL_PREFIX=/private/tmp/cvc5-20250521-54711-d6yrl1/build/deps' '-DCMAKE_TOOLCHAIN_FILE=' '-DLIBPOLY_BUILD_PYTHON_API=OFF' '-DLIBPOLY_BUILD_STATIC=ON' '-DLIBPOLY_BUILD_STATIC_PIC=ON' '-DGMP_INCLUDE_DIR=/opt/homebrew/include' '-DGMP_LIBRARY=/opt/homebrew/lib/libgmp.a' '-DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=TRUE' '-GUnix Makefiles' '-S' '/private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/Poly-EP' '-B' '/private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/Poly-EP-build'

  See also

    /private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/Poly-EP-stamp/Poly-EP-configure.log


-- Log output is:
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> sp/Poly-EP-configure.log


-- Log output is:
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!

CMake Error at /private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/Poly-EP-stamp/Poly-EP-configure-Production.cmake:47 (message):
  Stopping after outputting logs.


make[2]: *** [deps/src/Poly-EP-stamp/Poly-EP-configure] Error 1
make[1]: *** [CMakeFiles/Poly-EP.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
-- SymFPU-EP download command succeeded.  See also /private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/SymFPU-EP-stamp/SymFPU-EP-download-*.log
[  4%] Generating node_manager.h
[  4%] No patch step for 'CaDiCaL-EP'
[  4%] No update step for 'SymFPU-EP'
[  4%] Building CXX object src/base/CMakeFiles/cvc5base.dir/configuration.cpp.o
[  4%] Performing configure step for 'CaDiCaL-EP'
[  4%] No patch step for 'SymFPU-EP'
[  4%] No configure step for 'SymFPU-EP'
-- CaDiCaL-EP configure command succeeded.  See also /private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/CaDiCaL-EP-stamp/CaDiCaL-EP-configure-*.log
[  4%] Generating type_checker.cpp
[  4%] Performing build step for 'CaDiCaL-EP'
[  4%] No build step for 'SymFPU-EP'
[  5%] Performing install step for 'SymFPU-EP'
-- SymFPU-EP install command succeeded.  See also /private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/SymFPU-EP-stamp/SymFPU-EP-install-*.log
[  5%] Built target gen-theory
[  5%] Generating type_properties.h
[  5%] Completed 'SymFPU-EP'
[  5%] Built target SymFPU-EP
[  5%] Building CXX object src/base/CMakeFiles/cvc5base.dir/exception.cpp.o
[  5%] Building CXX object src/base/CMakeFiles/cvc5base.dir/listener.cpp.o
[  5%] Building CXX object src/base/CMakeFiles/cvc5base.dir/output.cpp.o
[  5%] Generating kind.cpp
[  5%] Building CXX object src/base/CMakeFiles/cvc5base.dir/versioninfo.cpp.o
[  5%] Built target gen-rewrites
[  5%] Built target cvc5base
[  5%] Generating type_properties.cpp
[  5%] Generating metakind.cpp
[  5%] Generating node_manager.cpp
[  5%] Built target gen-expr
-- CaDiCaL-EP build command succeeded.  See also /private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/CaDiCaL-EP-stamp/CaDiCaL-EP-build-*.log
[  5%] Performing install step for 'CaDiCaL-EP'
-- CaDiCaL-EP install command succeeded.  See also /private/tmp/cvc5-20250521-54711-d6yrl1/build/deps/src/CaDiCaL-EP-stamp/CaDiCaL-EP-install-*.log
[  5%] Completed 'CaDiCaL-EP'
[  5%] Built target CaDiCaL-EP
make: *** [all] Error 2

HOMEBREW_VERSION: 4.5.2
ORIGIN: https://github.com/Homebrew/brew
HEAD: 6f39076b3c2251994419215279d0525ef667fc31
Last commit: 12 days ago
Branch: stable
Core tap JSON: 21 May 13:32 UTC
Core cask tap JSON: 21 May 13:32 UTC
HOMEBREW_PREFIX: /opt/homebrew
HOMEBREW_CASK_OPTS: []
HOMEBREW_DISPLAY: /private/tmp/com.apple.launchd.rI3Y3qqpD3/org.xquartz:0
HOMEBREW_MAKE_JOBS: 10
HOMEBREW_NO_BOOTSNAP: set
HOMEBREW_SORBET_RUNTIME: set
Homebrew Ruby: 3.4.3 => /opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.3/bin/ruby
CPU: deca-core 64-bit arm_firestorm_icestorm
Clang: 17.0.0 build 1700
Git: 2.39.5 => /Applications/Xcode.app/Contents/Developer/usr/bin/git
Curl: 8.7.1 => /usr/bin/curl
macOS: 15.5-arm64
CLT: 16.3.0.0.1.1742442376
Xcode: 16.3
</details>