### PR TITLE
add --no-quarantine flag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## How do I install cvc5 as a cask?
 
-`brew install --cask cvc5/cvc5/cvc5`
+`brew install --cask --no-quarantine cvc5/cvc5/cvc5`
 
-Or `brew tap cvc5/cvc5` and then `brew install --cask cvc5`.
+Or `brew tap cvc5/cvc5` and then `brew install --cask --no-quarantine cvc5`.
 
 ## Documentation
 


### PR DESCRIPTION
As noted in https://github.com/cvc5/homebrew-cvc5/issues/18, the instructions in the README currently yield a broken installation of cvc5 on macOS because the `cvc5` binary is not signed or notarized. This produces the following warning message when `cvc5` is run:

<img width="535" height="436" alt="Screenshot 2025-10-29 at 14 59 08" src="https://github.com/user-attachments/assets/154c12f8-33e5-4312-a214-0b3c8267b8f4" />

This PR adds the `--no-quarantine` flag to the installation instructions to bypass the code signing check, which is necessary to produce a working installation.