### PR TITLE
Remove quarantine flag

### DIFF
--- a/Casks/cvc5.rb
+++ b/Casks/cvc5.rb
@@ -31,4 +31,10 @@ cask "cvc5" do
   caveats do
     license "https://github.com/cvc5/cvc5/blob/main/COPYING"
   end
+
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-r", "-d", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/cvc5"],
+                   sudo: false
+  end
 end

--- a/Casks/cvc5.rb
+++ b/Casks/cvc5.rb
@@ -28,13 +28,13 @@ cask "cvc5" do
     regex(/^cvc5-(\d+(?:\.\d+)+)$/i)
   end
 
-  caveats do
-    license "https://github.com/cvc5/cvc5/blob/main/COPYING"
-  end
-
   postflight do
     system_command "/usr/bin/xattr",
                    args: ["-r", "-d", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/cvc5"],
                    sudo: false
+  end
+
+  caveats do
+    license "https://github.com/cvc5/cvc5/blob/main/COPYING"
   end
 end


### PR DESCRIPTION
macOS Gatekeeper prevents the cvc5 binary from executing unless the `--no-quarantine` flag is passed to `brew`. This change removes the need to pass the flag.

Fixes #18